### PR TITLE
Fix "control characters" in Obsidian

### DIFF
--- a/Documents/Spells/Spells A.md
+++ b/Documents/Spells/Spells A.md
@@ -88,7 +88,7 @@ You assume a different form. When you cast the spell, choose one of the followin
 
 #### Animal Friendship
 
-*1st-­level enchantment*
+*1st-level enchantment*
 
 **Casting Time:** 1 action
 
@@ -100,7 +100,7 @@ You assume a different form. When you cast the spell, choose one of the followin
 
 This spell lets you convince a beast that you mean it no harm. Choose a beast that you can see within range. It must see and hear you. If the beast's Intelligence is 4 or higher, the spell fails. Otherwise, the beast must succeed on a Wisdom saving throw or be charmed by you for the spell's duration. If you or one of your companions harms the target, the spells ends.
 
-***At Higher Levels***. When you cast this spell using a  spell slot of 2nd level or higher, you can affect one additional beast t level above 1st.
+***At Higher Levels***. When you cast this spell using a spell slot of 2nd level or higher, you can affect one additional beast t level above 1st.
 
 #### Animal Messenger
 

--- a/Documents/Spells/Spells B.md
+++ b/Documents/Spells/Spells B.md
@@ -205,7 +205,7 @@ Your body becomes blurred, shifting and wavering to all who can see you. For the
 
 #### Branding Smite
 
-*2nd-­level evocation*
+*2nd-level evocation*
 
 **Casting Time:** 1 bonus action
 
@@ -215,9 +215,9 @@ Your body becomes blurred, shifting and wavering to all who can see you. For the
 
 **Duration:** Concentration, up to 1 minute
 
-The next time you hit a creature with a weapon attack before this spell ends, the weapon gleams with astral radiance as you strike. The attack deals an extra 2d6 radiant damage to the target, which becomes visible if it's invisible, and the target sheds dim light in a 5-­foot radius and can't become invisible until the spell ends. 
+The next time you hit a creature with a weapon attack before this spell ends, the weapon gleams with astral radiance as you strike. The attack deals an extra 2d6 radiant damage to the target, which becomes visible if it's invisible, and the target sheds dim light in a 5-foot radius and can't become invisible until the spell ends. 
 
-***At Higher Levels***. When you cast this spell using a  spell slot of 3rd level or higher, the extra damage increases by 1d6 for each slot level above 2nd. 
+***At Higher Levels***. When you cast this spell using a spell slot of 3rd level or higher, the extra damage increases by 1d6 for each slot level above 2nd. 
 
 #### Burning Hands
 

--- a/Documents/Spells/Spells C.md
+++ b/Documents/Spells/Spells C.md
@@ -270,7 +270,7 @@ This spell doesn't decode secret messages in a text or a glyph, such as an arcan
 
 #### Compulsion
 
-*4th-­level enchantment*
+*4th-level enchantment*
 
 **Casting Time:** 1 action
 
@@ -282,7 +282,7 @@ This spell doesn't decode secret messages in a text or a glyph, such as an arcan
 
 Creatures of your choice that you can see within range and that can hear you must make a Wisdom saving throw. A target automatically succeeds on this saving throw if it can't be charmed. On a failed save, a target is affected by this spell. Until the spell ends, you can use a bonus action on each of your turns to designate a direction that is horizontal to you. Each affected target must use as much of its movement as possible to move in that direction on its next turn. It can take its action before it moves. After moving in this way, it can make another Wisdom saving to try to end the effect. 
 
-A target isn't compelled to move into an obviously  deadly hazard, such as a fire or pit, but it will provoke opportunity attacks to move in the designated direction.
+A target isn't compelled to move into an obviously deadly hazard, such as a fire or pit, but it will provoke opportunity attacks to move in the designated direction.
 
 #### Cone of Cold
 
@@ -638,7 +638,7 @@ When you change the weather conditions, find a current condition on the followin
 
 #### Counterspell
 
-*3rd-­level abjuration*
+*3rd-level abjuration*
 
 **Casting Time:** 1 reaction, which you take when you see a creature within 60 feet of you casting a spell
 
@@ -650,7 +650,7 @@ When you change the weather conditions, find a current condition on the followin
 
 You attempt to interrupt a creature in the process of casting a spell. If the creature is casting a spell of 3rd level or lower, its spell fails and has no effect. If it is casting a spell of 4th level or higher, make an ability check using your spellcasting ability. The DC equals 10 + the spell's level. On a success, the creature's spell fails and has no effect.
 
-***At Higher Levels***. When you cast this spell using a spell slot of 4th level or higher, the interrupted spell has no effect if its level is less than or equal to the level of the spell slot you used. 
+***At Higher Levels***. When you cast this spell using a spell slot of 4th level or higher, the interrupted spell has no effect if its level is less than or equal to the level of the spell slot you used. 
 
 #### Create Food and Water
 

--- a/Documents/Spells/Spells E.md
+++ b/Documents/Spells/Spells E.md
@@ -42,7 +42,7 @@ A fissure that opens beneath a structure causes it to automatically collapse (se
 
 A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage.
 
-The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam. 
+The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam. 
 
 #### Enhance Ability
 

--- a/Documents/Spells/Spells F.md
+++ b/Documents/Spells/Spells F.md
@@ -120,7 +120,7 @@ The spell can also be ended by *greater restoration*, *heal*, or *wish*.
 
 #### Find Familiar
 
-*1st-­level conjuration (ritual)*
+*1st-level conjuration (ritual)*
 
 **Casting Time:** 1 hour
 
@@ -132,17 +132,17 @@ The spell can also be ended by *greater restoration*, *heal*, or *wish*.
 
 You gain the service of a familiar, a spirit that takes an animal form you choose: bat, cat, crab, frog (toad), hawk, lizard, octopus, owl, poisonous snake, fish (quipper), rat, raven, sea horse, spider, or weasel. Appearing in an unoccupied space within range, the familiar has the statistics of the chosen form, though it is a celestial, fey, or fiend (your choice) instead of a beast.
 
-Your familiar acts independently of you, but it always obeys your commands. In combat, it rolls its own initiative and acts on its own turn. A familiar can't attack, but it can take other actions as normal.
+Your familiar acts independently of you, but it always obeys your commands. In combat, it rolls its own initiative and acts on its own turn. A familiar can't attack, but it can take other actions as normal.
 
-When the familiar drops to 0 hit points, it disappears, leaving behind no physical form. It reappears after you cast this spell again. 
+When the familiar drops to 0 hit points, it disappears, leaving behind no physical form. It reappears after you cast this spell again. 
 
-While your familiar is within 100 feet of you, you  can communicate with it telepathically. Additionally, as an action, you can see through your familiar's eyes and hear what it hears until the start of your next turn, gaining the benefits of any special senses that the familiar has. During this time, you are deaf and blind with regard to your own senses.
+While your familiar is within 100 feet of you, you can communicate with it telepathically. Additionally, as an action, you can see through your familiar's eyes and hear what it hears until the start of your next turn, gaining the benefits of any special senses that the familiar has. During this time, you are deaf and blind with regard to your own senses.
 
-As an action, you can temporarily dismiss your familiar. It disappears into a pocket dimension where it awaits your summons. Alternatively, you can dismiss it forever. As an action while it is temporarily dismissed, you can cause it to reappear in any unoccupied space within 30 feet of you.
+As an action, you can temporarily dismiss your familiar. It disappears into a pocket dimension where it awaits your summons. Alternatively, you can dismiss it forever. As an action while it is temporarily dismissed, you can cause it to reappear in any unoccupied space within 30 feet of you.
 
-You can't have more than one familiar at a time. If you cast this spell while you already have a familiar, you instead cause it to adopt a new form. Choose one of the forms from the above list. Your familiar transforms into the chosen creature.
+You can't have more than one familiar at a time. If you cast this sp ell while you already have a familiar, you instead cause it to adopt a new form. Choose one of the forms from the above list. Your familiar transforms into the chosen creature.
 
-Finally, when you cast a spell with a range of touch, your familiar can deliver the spell as if it had cast the spell. Your familiar must be within 100 feet of you, and it must use its reaction to deliver the spell when you cast it. If the spell requires an attack roll, you use your attack modifier for the roll. 
+Finally, when you cast a spell with a range of touch, your familiar can deliver the spell as if it had cast the spell. Your familiar must be within 100 feet of you, and it must use its reaction to deliver the spell when you cast it. If the spell requires an attack roll, you use your attack modifier for the roll. 
 
 #### Find Steed
 
@@ -248,7 +248,7 @@ The fire spreads around corners. It ignites flammable objects in the area that a
 
 You hurl a mote of fire at a creature or object within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 fire damage. A flammable object hit by this spell ignites if it isn't being worn or carried. 
 
-This spell's damage increases by 1d10 when you  reach 5th level (2d10), 11th level (3d10), and 17th level (4d10). 
+This spell's damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10). 
 
 #### Fire Shield
 

--- a/Documents/Spells/Spells G.md
+++ b/Documents/Spells/Spells G.md
@@ -169,7 +169,7 @@ When you inscribe the glyph, choose *explosive runes* or a *spell glyph*.
 
 Up to ten berries appear in your hand and are infused with magic for the duration. A creature can use its action to eat one berry. Eating a berry restores 1 hit point, and the berry provides enough nourishment to sustain a creature for one day. 
 
-The berries lose their potency if they have not  been consumed within 24 hours of the casting of this spell. 
+The berries lose their potency if they have not been consumed within 24 hours of the casting of this spell. 
 
 #### Grease
 

--- a/Documents/Spells/Spells H.md
+++ b/Documents/Spells/Spells H.md
@@ -136,7 +136,7 @@ If a creature is holding or wearing the object and takes the damage from it, the
 
 #### Hellish Rebuke
 
-*1st-­level evocation*
+*1st-level evocation*
 
 **Casting Time:** 1 reaction, which you take in response to being damaged by a creature within 60 feet of you that you can see
 
@@ -148,7 +148,7 @@ If a creature is holding or wearing the object and takes the damage from it, the
 
 You point your finger, and the creature that damaged you is momentarily surrounded by hellish flames. The creature must make a Dexterity saving throw. It takes 2d10 fire damage on a failed save, or half as much damage on a successful one.
 
-***At Higher Levels***. When you cast this spell using a  spell slot of 2nd level or higher, the damage increases by 1d10 for each slot level above 1st. 
+***At Higher Levels***. When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d10 for each slot level above 1st. 
 
 #### Heroes' Feast
 
@@ -246,7 +246,7 @@ Divine light washes out from you and coalesces in a soft radiance in a 30-foot r
 
 #### Hunter's Mark
 
-*1st-­level divination*
+*1st-level divination*
 
 **Casting Time:** 1 bonus action
 
@@ -258,7 +258,7 @@ Divine light washes out from you and coalesces in a soft radiance in a 30-foot r
 
 You choose a creature you can see within range and mystically mark it as your quarry. Until the spell ends, you deal an extra 1d6 damage to the target whenever you hit it with a weapon attack, and you have advantage on any Wisdom (Perception) or Wisdom (Survival) check you make to find it. If the target drops to 0 hit points before this spell ends, you can use a bonus action on a subsequent turn of yours to mark a new creature.
 
-***At Higher Levels***. When you cast this spell using a  spell slot of 3rd or 4th level, you can maintain your concentration on the spell for up to 8 hours. When you use a spell slot of 5th level or higher, you can maintain your concentration on the spell for up to 24 hours.
+***At Higher Levels***. When you cast this spell using a spell slot of 3rd or 4th level, you can maintain your concentration on the spell for up to 8 hours. When you use a spell slot of 5th level or higher, you can maintain your concentration on the spell for up to 24 hours.
 
 #### Hypnotic Pattern
 

--- a/Documents/Spells/Spells P.md
+++ b/Documents/Spells/Spells P.md
@@ -156,7 +156,7 @@ If you cast this spell over 8 hours, you enrich the land. All plants in a half-m
 
 You extend your hand toward a creature you can see within range and project a puff of noxious gas from your palm. The creature must succeed on a Constitution saving throw or take 1d12 poison damage. 
 
-This spell's damage increases by 1d12 when you  reach 5th level (2d12), 11th level (3d12), and 17th level (4d12). 
+This spell's damage increases by 1d12 when you reach 5th level (2d12), 11th level (3d12), and 17th level (4d12). 
 
 #### Polymorph
 

--- a/Documents/Spells/Spells V.md
+++ b/Documents/Spells/Spells V.md
@@ -30,4 +30,4 @@ The touch of your shadow-wreathed hand can siphon life force from others to heal
 
 You unleash a string of insults laced with subtle enchantments at a creature you can see within range. If the target can hear you (though it need not understand you), it must succeed on a Wisdom saving throw or take 1d4 psychic damage and have disadvantage on the next attack roll it makes before the end of its next turn.
 
-This spell's damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).
+This spell's damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4).


### PR DESCRIPTION
In Obsidian, a few files showed red dots and had the tooltip "control character 0xad", such as the `Spells H.md` file in the "Hellish Rebuke" section. Only some spell files have this peculiarity.

I searched for all the "control characters" and removed them. This command helped me find them:

```
find Documents -type f -exec grep --binary -P "[\x80-\xff]" {} + | grep -v "[×½]"
```