### PR TITLE
remove redundant Inspiration content from Languages section

### DIFF
--- a/Characterizations/Languages.md
+++ b/Characterizations/Languages.md
@@ -33,19 +33,3 @@ Some of these languages are actually families of languages with many dialects. F
 | Sylvan      | Fey creatures       | Elvish    |
 | Undercommon | Underworld traders  | Elvish    |
 |             |                     |           |
-
-# Inspiration
-
-Inspiration is a rule the game master can use to reward you for playing your character in a way that's true to his or her personality traits, ideal, bond, and flaw. By using inspiration, you can draw on your personality trait of compassion for the downtrodden to give you an edge in negotiating with the Beggar Prince. Or inspiration can let you call on your bond to the defense of your home village to push past the effect of a spell that has been laid on you.
-
-## Gaining Inspiration
-
-Your GM can choose to give you inspiration for a variety of reasons. Typically, GMs award it when you play out your personality traits, give in to the drawbacks presented by a flaw or bond, and otherwise portray your character in a compelling way. Your GM will tell you how you can earn inspiration in the game.
-
-You either have inspiration or you don't - you can't stockpile multiple "inspirations" for later use.
-
-## Using Inspiration
-
-If you have inspiration, you can expend it when you make an attack roll, saving throw, or ability check. Spending your inspiration gives you advantage on that roll.
-
-Additionally, if you have inspiration, you can reward another player for good roleplaying, clever thinking, or simply doing something exciting in the game. When another player character does something that really contributes to the story in a fun and interesting way, you can give up your inspiration to give that character inspiration.


### PR DESCRIPTION
this content exists: https://github.com/OldManUmby/DND.SRD.Wiki/blob/master/Characterizations/Inspiration.md